### PR TITLE
Fix: Improve dark mode theme switching and decorative elements

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,10 +11,27 @@ html.dark .hero-pattern {
     background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%234a5568' fill-opacity='0.4'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E") !important;
 }
 
+.card-hover {
+    /* Apply transitions to the base class for smoother hover effects */
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
 .card-hover:hover {
     transform: translateY(-5px);
-    transition: transform 0.3s ease;
+    /* Tailwind's shadow-md is applied by default via HTML classes.
+       If a specific light-mode hover shadow different from the default shadow-md
+       were needed, it could be added here. For this case, we assume Tailwind's
+       default shadow on the card is sufficient for light mode hover indication
+       beyond the transform. */
 }
+
+/* Specific hover effect for dark mode cards */
+html.dark .card-hover:hover {
+    transform: translateY(-5px); /* Ensure transform is consistent */
+    /* Example: a subtle blue glow. Adjust color and spread as needed. */
+    box-shadow: 0 0 15px 2px rgba(59, 130, 246, 0.4);
+}
+
 .animate-float {
     animation: float 6s ease-in-out infinite;
 }


### PR DESCRIPTION
The theme switcher previously only fully updated the hero section's background for dark mode. Other decorative elements did not have explicit custom dark mode styling, relying mostly on Tailwind's default dark variants.

This commit introduces the following improvements:
- Added a distinct hover effect (subtle blue glow) for `.card-hover` elements specifically in dark mode to enhance visual feedback. This is achieved by adding a new CSS rule in `styles.css` for `html.dark .card-hover:hover`.
- Ensured that the transition property on `.card-hover` includes `box-shadow` for a smooth effect.
- Verified that other elements styled with Tailwind CSS `dark:` variants function correctly with the existing `theme.js` logic, which properly toggles a `dark` class on the `html` element.
- No changes to `theme.js` were necessary as it already correctly handles theme state and persistence.

The theme switcher now provides a more consistent and modern experience across both light and dark modes, with particular attention to interactive elements like cards.