### PR TITLE
Fix: Correct filter initialization in repository.js

### DIFF
--- a/js/repository.js
+++ b/js/repository.js
@@ -107,7 +107,9 @@
 
     // --- Dynamic Filter Population ---
     function populateDynamicFilters(syllabi) {
-        if (!termFiltersContainer || !levelFiltersContainer || !tagFiltersContainer) {
+        // Check yearFiltersContainer instead of tagFiltersContainer
+        const yearFiltersContainer = document.getElementById("year-filters-container");
+        if (!termFiltersContainer || !levelFiltersContainer || !yearFiltersContainer) {
             console.error("Filter container elements not found!");
             return;
         }
@@ -149,8 +151,10 @@
         // For levels, the value is "100", "200", etc. Label is "100-level"
         levels.forEach(levelFullText => levelFiltersContainer.appendChild(createCheckbox("level", levelFullText.substring(0,3), levelFullText)));
 
-        tagFiltersContainer.innerHTML = "";
-        tags.forEach(tag => tagFiltersContainer.appendChild(createCheckbox("tags", tag, tag)));
+        if (tagFiltersContainer) { // Only populate tags if the container exists
+            tagFiltersContainer.innerHTML = "";
+            tags.forEach(tag => tagFiltersContainer.appendChild(createCheckbox("tags", tag, tag)));
+        }
     }
 
     function renderSyllabusCards(syllabiToRender) {


### PR DESCRIPTION
The filter selection dropdowns for Term, Year, and Course Level were previously stuck showing a "loading..." message.

This was caused by two issues in `js/repository.js` within the `populateDynamicFilters` function:
1. An incorrect variable (`tagFiltersContainer` instead of `yearFiltersContainer`) was used in the initial check for the existence of filter container DOM elements. This could cause the function to exit prematurely if the `tagFiltersContainer` (which is optional and not present in `index.html`) was null.
2. The code attempted to populate tag filters using `tagFiltersContainer.innerHTML` without first checking if `tagFiltersContainer` was null.

The fix addresses these by:
- Correcting the variable in the initial DOM element check to use `yearFiltersContainer`.
- Moving the definition of `yearFiltersContainer` to before this check.
- Wrapping the tag filter population logic in a conditional block to ensure it only runs if `tagFiltersContainer` exists in the DOM.

These changes ensure that the Term, Year, and Course Level filters are correctly populated and functional.